### PR TITLE
Add validator for none selector

### DIFF
--- a/incubator/hnc/internal/validators/object_test.go
+++ b/incubator/hnc/internal/validators/object_test.go
@@ -381,6 +381,34 @@ func TestUserChanges(t *testing.T) {
 				},
 			},
 		},
+	}, {
+		name: "Deny creation of object with invalid noneSelect annotation",
+		fail: true,
+		inst: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{
+						api.AnnotationNoneSelector: "foo",
+					},
+				},
+			},
+		},
+	}, {
+		name: "Allow creation of object with valid noneSelect annotation",
+		fail: false,
+		inst: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{
+						api.AnnotationNoneSelector: "true",
+					},
+				},
+			},
+		},
 	}}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Tested: go test -v ./internal/validator

```
=== RUN   TestUserChanges/Deny_creation_of_object_with_invalid_noneSelect_annotation
    object_test.go:432: Got code 400, reason "BadRequest", message "invalid \"propagate.hnc.x-k8s.io/none\" value, it should be either true, false or empty, but got \"foo\""
=== RUN   TestUserChanges/Allow_creation_of_object_with_valid_noneSelect_annotation
    object_test.go:432: Got code 0, reason "", message "source object"
```